### PR TITLE
Fix "Error: unknown keyword: timeout"

### DIFF
--- a/custom_download_strategy.rb
+++ b/custom_download_strategy.rb
@@ -72,7 +72,7 @@ class GitHubPrivateRepositoryDownloadStrategy < CurlDownloadStrategy
 
   private
 
-  def _fetch(url:, resolved_url:)
+  def _fetch(url:, resolved_url:, timeout:)
     curl_download download_url, to: temporary_path
   end
 
@@ -125,7 +125,7 @@ class GitHubPrivateRepositoryReleaseDownloadStrategy < GitHubPrivateRepositoryDo
 
   private
 
-  def _fetch(url:, resolved_url:)
+  def _fetch(url:, resolved_url:, timeout:)
     # HTTP request header `Accept: application/octet-stream` is required.
     # Without this, the GitHub API will respond with metadata, not binary.
     curl_download download_url, "--header", "Accept: application/octet-stream", to: temporary_path


### PR DESCRIPTION
Changes in homebrew result in `Error: unknown keyword: timeout` and the install failing. This change addresses that issue by updating the relevant function signatures.